### PR TITLE
feat: Implemented additional REST API methods

### DIFF
--- a/connectors.go
+++ b/connectors.go
@@ -148,6 +148,16 @@ func (c *Client) UpdateConnectorConfig(name string, config ConnectorConfig) (*Co
 	return connector, response, err
 }
 
+// GetConnectorTaskStatus gets the status of task for a connector.
+//
+// See: https://docs.confluent.io/current/connect/references/restapi.html#get--connectors-(string-name)-tasks-(int-taskid)-status
+func (c *Client) GetConnectorTaskStatus(name string, taskID int) (*TaskState, *http.Response, error) {
+	path := fmt.Sprintf("connectors/%v/tasks/%v/status", name, taskID)
+	status := new(TaskState)
+	respnse, err := c.get(path, status)
+	return status, respnse, err
+}
+
 // DeleteConnector deletes a connector with the given name, halting all tasks
 // and deleting its configuration.
 //
@@ -180,5 +190,13 @@ func (c *Client) ResumeConnector(name string) (*http.Response, error) {
 // See http://docs.confluent.io/current/connect/userguide.html#post--connectors-(string-name)-restart
 func (c *Client) RestartConnector(name string) (*http.Response, error) {
 	path := fmt.Sprintf("connectors/%v/restart", name)
+	return c.doRequest("POST", path, nil, nil)
+}
+
+// RestartConnectorTask restarts a tasks for a connector.
+//
+// See https://docs.confluent.io/current/connect/references/restapi.html#post--connectors-(string-name)-tasks-(int-taskid)-restart
+func (c *Client) RestartConnectorTask(name string, taskID int) (*http.Response, error) {
+	path := fmt.Sprintf("connectors/%v/tasks/%v/restart", name, taskID)
 	return c.doRequest("POST", path, nil, nil)
 }

--- a/plugins.go
+++ b/plugins.go
@@ -1,0 +1,21 @@
+package connect
+
+import "net/http"
+
+// Plugin represents a Kafka Connect connector plugin
+type Plugin struct {
+	Class   string `json:"class"`
+	Type    string `json:"type"`
+	Version string `json:"version"`
+}
+
+// ListPlugins retrieves a list of the installed plugins.
+//
+// See: https://docs.confluent.io/current/connect/references/restapi.html#get--connector-plugins-
+func (c *Client) ListPlugins() ([]*Plugin, *http.Response, error) {
+	path := "connector-plugins"
+	var names []*Plugin
+
+	response, err := c.get(path, &names)
+	return names, response, err
+}

--- a/plugins_test.go
+++ b/plugins_test.go
@@ -1,0 +1,51 @@
+package connect_test
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+
+	. "github.com/go-kafka/connect"
+)
+
+var _ = Describe("Plugins Tests", func() {
+	BeforeEach(func() {
+		server = ghttp.NewServer()
+		client = NewClient(server.URL())
+	})
+
+	AfterEach(func() {
+		server.Close()
+	})
+
+	Describe("ListPlugins", func() {
+		var statusCode int
+		resultPlugins := []*Plugin{
+			&Plugin{
+				Class:   "test-class",
+				Type:    "source",
+				Version: "5.3.0",
+			},
+		}
+
+		BeforeEach(func() {
+			statusCode = http.StatusOK
+
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/connector-plugins"),
+					ghttp.VerifyHeader(jsonAcceptHeader),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, &resultPlugins),
+				),
+			)
+		})
+
+		It("returns list of connector plugins", func() {
+			plugins, _, err := client.ListPlugins()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(plugins).To(Equal(resultPlugins))
+		})
+	})
+})


### PR DESCRIPTION
Added support for the following:
- Getting the status of a specific task for a connector
- Restarting a specific task for a connector
- Getting a list of connector plugins

Signed-off-by: Richard Case <198425+richardcase@users.noreply.github.com>