### PR TITLE
Add `ConnectorState.Trace` field

### DIFF
--- a/connectors.go
+++ b/connectors.go
@@ -52,6 +52,7 @@ type ConnectorStatus struct {
 type ConnectorState struct {
 	State    string `json:"state"`
 	WorkerID string `json:"worker_id"`
+	Trace    string `json:"trace,omitempty"`
 }
 
 // TaskState reflects the running state of a Task and the worker where it is


### PR DESCRIPTION
[Kafka Connect's official API doc](https://docs.confluent.io/platform/current/connect/references/restapi.html) doesn't have this field but the implementation has it:

* https://github.com/apache/kafka/blob/f0282498e7a312a977acb127557520def338d45c/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractStatus.java#L46
* https://github.com/apache/kafka/blob/3cdc78e6bb1f83973a14ce1550fe3874f7348b05/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorStatus.java#L23

This field contains the errors of the connector when there is no task.